### PR TITLE
Replace nerd font bash prompts with ASCII-only design

### DIFF
--- a/apple/bash/prompt
+++ b/apple/bash/prompt
@@ -2,6 +2,6 @@
 force_color_prompt=yes
 color_prompt=yes
 
-# Simple prompt with path in the window/pane title and caret for typing line
-PS1=$'\uf0a9 '
+# Minimal prompt with path in title and clean caret
+PS1='\[\033[1;36m\]>\[\033[0m\] '
 PS1="\[\e]0;\w\a\]$PS1"

--- a/archlinux/bash/prompt
+++ b/archlinux/bash/prompt
@@ -2,6 +2,6 @@
 force_color_prompt=yes
 color_prompt=yes
 
-# Simple prompt with path in the window/pane title and caret for typing line
-PS1=$'\uf0a9 '
+# Minimal prompt with path in title and clean caret
+PS1='\[\033[1;36m\]>\[\033[0m\] '
 PS1="\[\e]0;\w\a\]$PS1"


### PR DESCRIPTION
## Summary
• Replaces nerd font character (`\uf0a9`) with clean cyan `>` symbol in bash prompts
• Updates both `apple/bash/prompt` and `archlinux/bash/prompt` configurations
• Maintains minimalistic aesthetic while ensuring universal terminal compatibility

## Changes
- **Before**: Required nerd fonts to display prompt correctly
- **After**: Uses standard ASCII characters with cyan coloring for visual appeal
- **Compatibility**: Works across all terminals without font dependencies

## Test plan
- [ ] Test prompt display on macOS terminal
- [ ] Test prompt display on Linux terminal  
- [ ] Verify no font dependencies required
- [ ] Confirm window title functionality still works